### PR TITLE
laziness post sto

### DIFF
--- a/rep_lang_concrete_syntax/examples/stdlib.rl
+++ b/rep_lang_concrete_syntax/examples/stdlib.rl
@@ -1,0 +1,61 @@
+(defn map
+  (fix (lam [map]
+    (lam [f xs]
+      (if (null xs)
+        xs
+        (let ([x_ (f (head xs))])
+          (cons
+            x_
+            (map f (tail xs)))))))))
+
+(defn foldl
+  (fix (lam [foldl]
+    (lam [f acc xs]
+      (if (null xs)
+        acc
+        (foldl
+          f
+          (f acc (head xs))
+          (tail xs)))))))
+
+(defn take
+  (fix (lam [take]
+    (lam [n xs]
+      (if (== 0 n)
+        nil
+        (if (null xs)
+          xs
+          (cons
+            (head xs)
+            (take (- n 1) (tail xs)))))))))
+
+(defn repeat
+  (fix (lam [repeat]
+    (let ([cns cons])
+      (lam [x]
+        (cns x (repeat x)))))))
+
+(defn enumFromTo
+  (lam [start end]
+    (let ([go
+           (fix (lam [go]
+             (lam [x]
+               (if (== x end)
+                 nil
+                 (cons x (go (+ x 1)))))))])
+      (go start))))
+
+(defn sum
+  (lam [xs]
+    (foldl + 0 xs)))
+
+(defn ex1
+  (sum
+    (map (+ 1)
+         (take 3 (list 9 8 7 6)))))
+
+(defn ex2 (take 9 (repeat 1)))
+
+(defn ex3 (sum (enumFromTo 0 20)))
+
+ex3

--- a/rep_lang_concrete_syntax/src/parse.rs
+++ b/rep_lang_concrete_syntax/src/parse.rs
@@ -93,11 +93,14 @@ where
     let if_ = (res_str("if"), expr(), expr(), expr())
         .map(|t| Expr::If(Box::new(t.1), Box::new(t.2), Box::new(t.3)));
 
+    let fix = (res_str("fix"), expr()).map(|t| Expr::Fix(Box::new(t.1)));
+
     let parenthesized = choice((
         attempt(lam),
         attempt(let_),
         attempt(list),
         attempt(if_),
+        attempt(fix),
         app,
     ));
 
@@ -224,8 +227,8 @@ where
 
 pub fn reserved() -> Vec<String> {
     [
-        "let", "lam", "true", "false", "if", "null", "pair", "fst", "snd", "cons", "defn", "list",
-        "nil",
+        "let", "lam", "fix", "true", "false", "if", "null", "pair", "fst", "snd", "cons", "defn",
+        "list", "nil",
     ]
     .iter()
     .map(|x| x.to_string())

--- a/rep_lang_concrete_syntax/src/parse.rs
+++ b/rep_lang_concrete_syntax/src/parse.rs
@@ -42,6 +42,8 @@ where
         res_str("snd").map(|_| PrimOp::Snd),
         res_str("cons").map(|_| PrimOp::Cons),
         res_str("nil").map(|_| PrimOp::Nil),
+        res_str("head").map(|_| PrimOp::Head),
+        res_str("tail").map(|_| PrimOp::Tail),
     ))
     .map(Expr::Prim);
 
@@ -228,7 +230,7 @@ where
 pub fn reserved() -> Vec<String> {
     [
         "let", "lam", "fix", "true", "false", "if", "null", "pair", "fst", "snd", "cons", "defn",
-        "list", "nil",
+        "list", "nil", "head", "tail",
     ]
     .iter()
     .map(|x| x.to_string())

--- a/rep_lang_concrete_syntax/src/pretty.rs
+++ b/rep_lang_concrete_syntax/src/pretty.rs
@@ -47,6 +47,7 @@ pub fn ppr_expr(expr: &Expr) -> RcDoc<()> {
             let docs = vec![RcDoc::text("if"), tst_, thn_, els_];
             parens(RcDoc::intersperse(docs, sp!()))
         }
+        Fix(x) => parens(RcDoc::text("fix ").append(ppr_expr(x))),
         Prim(op) => ppr_primop(op),
     }
 }

--- a/rep_lang_concrete_syntax/src/pretty.rs
+++ b/rep_lang_concrete_syntax/src/pretty.rs
@@ -73,6 +73,8 @@ pub fn ppr_primop(op: &PrimOp) -> RcDoc<()> {
         Snd => RcDoc::text("snd"),
         Cons => RcDoc::text("cons"),
         Nil => RcDoc::text("nil"),
+        Head => RcDoc::text("head"),
+        Tail => RcDoc::text("tail"),
     }
 }
 

--- a/rep_lang_concrete_syntax/src/test/parse_pretty.rs
+++ b/rep_lang_concrete_syntax/src/test/parse_pretty.rs
@@ -38,6 +38,9 @@ pub mod parse_unit {
     fn e2() -> Expr {
         App(Box::new(e1()), Box::new(e1()))
     }
+    fn e3() -> Expr {
+        Fix(Box::new(e0()))
+    }
     fn e4() -> Expr {
         If(Box::new(e0()), Box::new(e0()), Box::new(e0()))
     }
@@ -61,6 +64,11 @@ pub mod parse_unit {
     #[test]
     fn ex2() {
         check_parse_expr!("((lam [x] x) (lam [x] x))", e2());
+    }
+
+    #[test]
+    fn ex3() {
+        check_parse_expr!("(fix x)", e3());
     }
 
     #[test]

--- a/rep_lang_core/src/abstract_syntax.rs
+++ b/rep_lang_core/src/abstract_syntax.rs
@@ -9,6 +9,7 @@ pub enum Expr {
     Let(Name, Box<Expr>, Box<Expr>),
     Lit(Lit),
     If(Box<Expr>, Box<Expr>, Box<Expr>),
+    Fix(Box<Expr>),
     Prim(PrimOp),
 }
 

--- a/rep_lang_core/src/abstract_syntax.rs
+++ b/rep_lang_core/src/abstract_syntax.rs
@@ -46,6 +46,8 @@ pub enum PrimOp {
     Snd,
     Cons,
     Nil,
+    Head,
+    Tail,
 }
 
 #[derive(Clone, Debug)]
@@ -72,5 +74,7 @@ pub fn primop_arity(op: &PrimOp) -> usize {
         PrimOp::Snd => 1,
         PrimOp::Cons => 2,
         PrimOp::Nil => 0,
+        PrimOp::Head => 1,
+        PrimOp::Tail => 1,
     }
 }

--- a/rep_lang_core/src/test_helpers/abstract_syntax.rs
+++ b/rep_lang_core/src/test_helpers/abstract_syntax.rs
@@ -133,7 +133,7 @@ pub fn arbitrary_name<G: Gen>(g: &mut G, reserved: &[String]) -> Name {
 
 #[allow(dead_code)]
 pub fn arbitrary_primop<G: Gen>(g: &mut G) -> PrimOp {
-    match g.gen_range(0, 10) {
+    match g.gen_range(0, 12) {
         0 => PrimOp::Add,
         1 => PrimOp::Sub,
         2 => PrimOp::Mul,
@@ -144,6 +144,8 @@ pub fn arbitrary_primop<G: Gen>(g: &mut G) -> PrimOp {
         7 => PrimOp::Snd,
         8 => PrimOp::Cons,
         9 => PrimOp::Nil,
+        10 => PrimOp::Head,
+        11 => PrimOp::Tail,
         _ => panic!("impossible: Arbitrary: PrimOp: gen out of bounds"),
     }
 }

--- a/rep_lang_runtime/src/bin/rl-iter.rs
+++ b/rep_lang_runtime/src/bin/rl-iter.rs
@@ -1,0 +1,30 @@
+use rep_lang_concrete_syntax::{util::pretty::to_pretty};
+
+use rep_lang_runtime::{
+    eval::{add_to_sto, lookup_sto, new_term_env, value_to_flat_thunk, EvalState, Sto},
+    thunk_util::i64_vec_to_flat_thunk_list,
+};
+
+fn main() -> std::io::Result<()> {
+    let width = 80;
+
+    let mut env = new_term_env();
+    let mut es = EvalState::new();
+    let mut sto = Sto::new();
+    let vec: Vec<i64> = vec![1,2,3,4];
+    let itr_thnk = i64_vec_to_flat_thunk_list(vec);
+    let vr = add_to_sto(itr_thnk, &mut sto);
+    let nm = es.fresh();
+    env.insert(nm, vr);
+    let val = lookup_sto(&mut es, &vr, &mut sto);
+    let result_flat_thunk = value_to_flat_thunk(&mut es, &val, &mut sto);
+    let val_str = to_pretty(result_flat_thunk.ppr(), width);
+    println!("sto: [");
+    for (idx, elem) in sto.sto_vec.iter().enumerate() {
+        println!("\t{} : {:?}", idx, elem);
+    }
+    println!("]");
+    println!("sto len: {}\n", sto.sto_vec.len());
+    println!("{}\n)", val_str);
+    Ok(())
+}

--- a/rep_lang_runtime/src/bin/rl-iter.rs
+++ b/rep_lang_runtime/src/bin/rl-iter.rs
@@ -1,4 +1,4 @@
-use rep_lang_concrete_syntax::{util::pretty::to_pretty};
+use rep_lang_concrete_syntax::util::pretty::to_pretty;
 
 use rep_lang_runtime::{
     eval::{add_to_sto, lookup_sto, new_term_env, value_to_flat_thunk, EvalState, Sto},
@@ -11,7 +11,7 @@ fn main() -> std::io::Result<()> {
     let mut env = new_term_env();
     let mut es = EvalState::new();
     let mut sto = Sto::new();
-    let vec: Vec<i64> = vec![1,2,3,4];
+    let vec: Vec<i64> = vec![1, 2, 3, 4];
     let itr_thnk = i64_vec_to_flat_thunk_list(vec);
     let vr = add_to_sto(itr_thnk, &mut sto);
     let nm = es.fresh();

--- a/rep_lang_runtime/src/bin/rle.rs
+++ b/rep_lang_runtime/src/bin/rle.rs
@@ -36,7 +36,12 @@ fn main() -> std::io::Result<()> {
                         let val = lookup_sto(&mut es, &vr, &mut sto);
                         let result_flat_thunk = value_to_flat_thunk(&mut es, &val, &mut sto);
                         let val_str = to_pretty(result_flat_thunk.ppr(), width);
-                        println!("sto: {:?}\nsto len: {}\n", sto.sto_vec, sto.sto_vec.len());
+                        println!("sto: [");
+                        for elem in &sto.sto_vec {
+                            println!("\t{:?}", elem);
+                        }
+                        println!("]");
+                        println!("sto len: {}\n", sto.sto_vec.len());
                         println!("(: {}\n   {}\n)", val_str, ty);
                         Ok(())
                     }

--- a/rep_lang_runtime/src/bin/rle.rs
+++ b/rep_lang_runtime/src/bin/rle.rs
@@ -7,7 +7,7 @@ use rep_lang_concrete_syntax::{parse::program, util::pretty::to_pretty};
 
 use rep_lang_runtime::{
     env::Env,
-    eval::{eval_program, lookup_sto, value_to_flat_thunk},
+    eval::{eval_program, lookup_sto, new_term_env, value_to_flat_thunk, EvalState, Sto},
     infer::infer_program,
 };
 
@@ -29,9 +29,12 @@ fn main() -> std::io::Result<()> {
                     Ok((sc, env)) => {
                         println!("{:?}\n\n{:?}\n", sc, env);
                         let ty = to_pretty(sc.ppr(), width);
-                        let (vr, _env, mut sto) = eval_program(&prog);
-                        let val = lookup_sto(&vr, &mut sto);
-                        let result_flat_thunk = value_to_flat_thunk(&val, &mut sto);
+                        let mut env = new_term_env();
+                        let mut es = EvalState::new();
+                        let mut sto = Sto::new();
+                        let vr = eval_program(&mut env, &mut sto, &mut es, &prog);
+                        let val = lookup_sto(&mut es, &vr, &mut sto);
+                        let result_flat_thunk = value_to_flat_thunk(&mut es, &val, &mut sto);
                         let val_str = to_pretty(result_flat_thunk.ppr(), width);
                         println!("sto: {:?}\nsto len: {}\n", sto.sto_vec, sto.sto_vec.len());
                         println!("(: {}\n   {}\n)", val_str, ty);

--- a/rep_lang_runtime/src/bin/rle.rs
+++ b/rep_lang_runtime/src/bin/rle.rs
@@ -7,7 +7,7 @@ use rep_lang_concrete_syntax::{parse::program, util::pretty::to_pretty};
 
 use rep_lang_runtime::{
     env::Env,
-    eval::{eval_program, lookup_sto, ppr_value_ref},
+    eval::{eval_program, lookup_sto, value_to_flat_thunk},
     infer::infer_program,
 };
 
@@ -29,9 +29,10 @@ fn main() -> std::io::Result<()> {
                     Ok((sc, env)) => {
                         println!("{:?}\n\n{:?}\n", sc, env);
                         let ty = to_pretty(sc.ppr(), width);
-                        let (vr, _env, sto) = eval_program(&prog);
-                        let val = lookup_sto(&vr, &sto);
-                        let val_str = to_pretty(ppr_value_ref(val, &sto), width);
+                        let (vr, _env, mut sto) = eval_program(&prog);
+                        let val = lookup_sto(&vr, &mut sto);
+                        let result_flat_thunk = value_to_flat_thunk(&val, &mut sto);
+                        let val_str = to_pretty(result_flat_thunk.ppr(), width);
                         println!("sto: {:?}\nsto len: {}\n", sto.sto_vec, sto.sto_vec.len());
                         println!("(: {}\n   {}\n)", val_str, ty);
                         Ok(())

--- a/rep_lang_runtime/src/bin/rli.rs
+++ b/rep_lang_runtime/src/bin/rli.rs
@@ -50,8 +50,9 @@ fn main() {
                                     let ty = to_pretty(sc.ppr(), width);
                                     type_env.extend(nm.clone(), sc);
                                     let vr = eval_(&term_env, &mut sto, &mut es, &e);
-                                    let val = lookup_sto(&vr, &mut sto);
-                                    let result_flat_thunk = value_to_flat_thunk(&val, &mut sto);
+                                    let val = lookup_sto(&mut es, &vr, &mut sto);
+                                    let result_flat_thunk =
+                                        value_to_flat_thunk(&mut es, &val, &mut sto);
                                     let val_str = to_pretty(result_flat_thunk.ppr(), width);
                                     term_env.insert(nm, vr);
                                     println!("(: {}\n   {}\n)", val_str, ty);

--- a/rep_lang_runtime/src/bin/rli.rs
+++ b/rep_lang_runtime/src/bin/rli.rs
@@ -6,7 +6,7 @@ use rep_lang_core::abstract_syntax::Defn;
 
 use rep_lang_runtime::{
     env::*,
-    eval::{eval_, lookup_sto, new_term_env, ppr_value_ref, EvalState, Sto},
+    eval::{eval_, lookup_sto, new_term_env, value_to_flat_thunk, EvalState, Sto},
     infer::*,
 };
 
@@ -50,8 +50,9 @@ fn main() {
                                     let ty = to_pretty(sc.ppr(), width);
                                     type_env.extend(nm.clone(), sc);
                                     let vr = eval_(&term_env, &mut sto, &mut es, &e);
-                                    let val = lookup_sto(&vr, &sto);
-                                    let val_str = to_pretty(ppr_value_ref(val, &sto), width);
+                                    let val = lookup_sto(&vr, &mut sto);
+                                    let result_flat_thunk = value_to_flat_thunk(&val, &mut sto);
+                                    let val_str = to_pretty(result_flat_thunk.ppr(), width);
                                     term_env.insert(nm, vr);
                                     println!("(: {}\n   {}\n)", val_str, ty);
                                 }

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -137,12 +137,10 @@ pub fn lookup_sto<'a>(es: &mut EvalState, vr: &VRef, sto: &'a mut Sto) -> Value<
             sto.sto_vec[idx] = Ev(val.clone());
             val
         }
-        _ => todo!(),
+        UnevRust(_clo) => todo!(),
     }
 }
 
-// TODO this is a call site where many critical points pass through. need to
-// review what should be un/evaluated.
 pub fn add_to_sto(thnk: Thunk<VRef>, sto: &mut Sto) -> VRef {
     match thnk {
         Ev(ref val) => {

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -25,9 +25,13 @@ pub enum Value<R> {
     VPair(R, R),
 }
 
+// TODO add thunk type
+
+// TODO this must wrap Thunk
 #[derive(Debug, PartialEq)]
 pub struct FlatValue(pub Value<Box<FlatValue>>);
 
+// TODO modify this to mirror `FlatValue` changes
 #[macro_export]
 macro_rules! vcons {
     ( $a: expr, $b: expr ) => {
@@ -56,6 +60,8 @@ pub fn new_term_env() -> TermEnv {
 
 #[derive(Debug)]
 pub struct Sto {
+    // TODO change this to Thunk<VRef>
+    //               |
     pub sto_vec: Vec<Value<VRef>>,
     // instead of using `Value<VRef>` as keys (which would store the whole value
     // in the HashMap), we only store a hash as key.
@@ -73,6 +79,10 @@ impl Sto {
     }
 }
 
+// TODO decide if this should return a `Value` (thereby forcing the thunk at
+// the provided index), or a `Thunk` (which could still be unevaluated).
+//
+// `Value` is probably the right decision.
 pub fn lookup_sto<'a>(vr: &VRef, sto: &'a Sto) -> &'a Value<VRef> {
     let VRef(idx) = *vr;
     match sto.sto_vec.get(idx) {
@@ -312,6 +322,9 @@ pub fn eval_(env: &TermEnv, sto: &mut Sto, es: &mut EvalState, expr: &Expr) -> V
                         let nm2 = nm.clone();
                         let bd2 = bd.clone();
                         let mut new_env = clo.clone();
+                        // it's possible we need to
+                        // delay this ------------------+
+                        // or it might just work.       |
                         let arg_v = eval_(env, sto, es, arg);
                         new_env.insert(nm2, arg_v);
                         eval_(&new_env, sto, es, &bd2)

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -416,11 +416,9 @@ pub fn eval_(env: &TermEnv, sto: &mut Sto, es: &mut EvalState, expr: &Expr) -> V
                         let nm2 = nm.clone();
                         let bd2 = bd.clone();
                         let mut new_env = clo.clone();
-                        // TODO it's possible we need to
-                        // delay this ------------------+
-                        // or it might just work.       |
-                        let arg_v = eval_(env, sto, es, arg);
-                        new_env.insert(nm2, arg_v);
+                        let arg_thnk = UnevExpr(*arg.clone(), env.clone());
+                        let arg_thnk_ref = add_to_sto(arg_thnk, sto);
+                        new_env.insert(nm2, arg_thnk_ref);
                         eval_(&new_env, sto, es, &bd2)
                     }
                     _ => panic!("impossible: non-closure in function position of app"),

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -394,6 +394,16 @@ pub fn eval_(env: &TermEnv, sto: &mut Sto, es: &mut EvalState, expr: &Expr) -> V
                     let val = VCons(args_v[0], args_v[1]);
                     add_to_sto(Ev(val), sto)
                 }
+                PrimOp::Head => match lookup_sto(es, &args_v[0], sto) {
+                    VCons(hd, _tl) => hd,
+                    VNil => panic!("head: called on empty list"),
+                    _ => panic!("head: bad types"),
+                },
+                PrimOp::Tail => match lookup_sto(es, &args_v[0], sto) {
+                    VCons(_hd, tl) => tl,
+                    VNil => panic!("tail: called on empty list"),
+                    _ => panic!("tail: bad types"),
+                },
                 PrimOp::Nil => panic!("nil: application of non-function"),
             }
         }

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -476,6 +476,13 @@ pub fn eval_(env: &TermEnv, sto: &mut Sto, es: &mut EvalState, expr: &Expr) -> V
                     _ => panic!("impossible: non-closure in function position of app"),
                 }
             }
+
+            Expr::Fix(e) => eval_(
+                env,
+                sto,
+                es,
+                &Expr::App(e.clone(), Box::new(Expr::Fix(e.clone()))),
+            ),
         },
     }
 }

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -37,13 +37,18 @@ pub enum Thunk<R> {
 #[derive(Debug, PartialEq)]
 pub struct FlatThunk(pub Thunk<Box<FlatThunk>>);
 
+// FlatThunk Ev
+#[macro_export]
+macro_rules! fte {
+    ( $a: expr ) => {
+        FlatThunk(Thunk::Ev($a))
+    };
+}
+
 #[macro_export]
 macro_rules! vcons {
     ( $a: expr, $b: expr ) => {
-        FlatThunk(Value::VCons(
-            Box::new(Thunk::Ev($a)),
-            Box::new(Thunk::Ev($b)),
-        ))
+        FlatThunk(Thunk::Ev(Value::VCons(Box::new($a), Box::new($b))))
     };
 }
 

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -123,6 +123,12 @@ impl Sto {
     }
 }
 
+impl Default for Sto {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // TODO this likely performs significant amounts of cloning.
 pub fn lookup_sto<'a>(es: &mut EvalState, vr: &VRef, sto: &'a mut Sto) -> Value<VRef> {
     let VRef(idx) = *vr;
@@ -323,10 +329,10 @@ impl Default for EvalState {
 
 pub fn eval_program(env: &mut TermEnv, sto: &mut Sto, es: &mut EvalState, prog: &Program) -> VRef {
     for Defn(nm, bd) in prog.p_defns.iter() {
-        let vr = eval_(&env, sto, es, bd);
+        let vr = eval_(env, sto, es, bd);
         env.insert(nm.clone(), vr);
     }
-    eval_(&env, sto, es, &prog.p_body)
+    eval_(env, sto, es, &prog.p_body)
 }
 
 pub fn eval(sto: &mut Sto, expr: &Expr) -> VRef {
@@ -475,13 +481,11 @@ pub fn eval_(env: &TermEnv, sto: &mut Sto, es: &mut EvalState, expr: &Expr) -> V
                 let fun_val = lookup_sto(es, &fun_ref, sto);
                 match fun_val {
                     VClosure(nm, bd, clo) => {
-                        let nm2 = nm.clone();
-                        let bd2 = bd.clone();
-                        let mut new_env = clo.clone();
+                        let mut new_env = clo;
                         let arg_thnk = UnevExpr(*arg.clone(), env.clone());
                         let arg_thnk_ref = add_to_sto(arg_thnk, sto);
-                        new_env.insert(nm2, arg_thnk_ref);
-                        eval_(&new_env, sto, es, &bd2)
+                        new_env.insert(nm, arg_thnk_ref);
+                        eval_(&new_env, sto, es, &bd)
                     }
                     _ => panic!("impossible: non-closure in function position of app"),
                 }

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -126,18 +126,18 @@ impl Sto {
 // TODO this likely performs significant amounts of cloning.
 pub fn lookup_sto<'a>(es: &mut EvalState, vr: &VRef, sto: &'a mut Sto) -> Value<VRef> {
     let VRef(idx) = *vr;
-    match sto.sto_vec.get_mut(idx) {
-        None => panic!("lookup_sto: out of bounds"),
-        Some(thnk) => match thnk {
-            Ev(val) => val.clone(),
-            UnevExpr(expr, env) => {
-                let expr2 = expr.clone();
-                let env2 = env.clone();
-                let vr2 = eval_(&env2, sto, es, &expr2);
-                lookup_sto(es, &vr2, sto)
-            }
-            _ => todo!(),
-        },
+    match &sto.sto_vec[idx] {
+        Ev(val) => val.clone(),
+        UnevExpr(expr, env) => {
+            let expr2 = expr.clone();
+            let env2 = env.clone();
+            let vr2 = eval_(&env2, sto, es, &expr2);
+            let val = lookup_sto(es, &vr2, sto);
+            // TODO perhaps we can avoid this by using references
+            sto.sto_vec[idx] = Ev(val.clone());
+            val
+        }
+        _ => todo!(),
     }
 }
 

--- a/rep_lang_runtime/src/infer.rs
+++ b/rep_lang_runtime/src/infer.rs
@@ -491,6 +491,17 @@ pub fn infer_primop(is: &mut InferState, op: &PrimOp) -> Type {
             type_arr_multi(vec![a, ls.clone()], ls)
         }
         PrimOp::Nil => type_list(is.fresh()),
+        PrimOp::Head => {
+            let a = is.fresh();
+            let ls = type_list(a.clone());
+            type_arr(ls, a)
+        }
+        PrimOp::Tail => {
+            let a = is.fresh();
+            let ls1 = type_list(a);
+            let ls2 = ls1.clone();
+            type_arr(ls1, ls2)
+        }
     }
 }
 

--- a/rep_lang_runtime/src/infer.rs
+++ b/rep_lang_runtime/src/infer.rs
@@ -218,6 +218,13 @@ fn infer(
             csts_e.append(&mut csts_bd);
             Ok((t_bd, csts_e))
         }
+        Expr::Fix(bd) => {
+            let (t_bd, mut csts_bd) = infer(env, is, bd)?;
+            let tv = is.fresh();
+            let cst = Constraint(t_bd, Type::TArr(Box::new(tv.clone()), Box::new(tv.clone())));
+            csts_bd.push(cst);
+            Ok((tv, csts_bd))
+        }
         Expr::Prim(op) => {
             // TODO figure out if this is borked. `poly` takes the approach of
             // wrapping primop application, whereas I allow primops to be first

--- a/rep_lang_runtime/src/lib.rs
+++ b/rep_lang_runtime/src/lib.rs
@@ -8,6 +8,7 @@ extern crate quickcheck_macros;
 pub mod env;
 pub mod eval;
 pub mod infer;
+pub mod thunk_util;
 pub mod toplevel;
 pub mod types;
 

--- a/rep_lang_runtime/src/thunk_util.rs
+++ b/rep_lang_runtime/src/thunk_util.rs
@@ -25,3 +25,21 @@ where
         }
     })
 }
+
+pub fn i64_vec_to_flat_thunk_list(vec: Vec<i64>) -> Thunk<VRef> {
+    UnevRust(Box::new(rec_vec(vec, 0)))
+}
+
+fn rec_vec(vec: Vec<i64>, idx: usize) -> Box<dyn FnMut() -> FlatThunk> {
+    Box::new(move || {
+        if idx >= vec.len() {
+            FlatThunk(Ev(VNil))
+        } else {
+            let hd = Box::new(FlatThunk(Ev(VInt(vec[idx]))));
+                // this seems suboptimal, due to excessive cloning, but I'm
+                // not sure how to do better ----------------\/
+            let tl = Box::new(FlatThunk(UnevRust(rec_vec(vec.clone(), idx + 1))));
+            FlatThunk(Ev(VCons(hd, tl)))
+        }
+    })
+}

--- a/rep_lang_runtime/src/thunk_util.rs
+++ b/rep_lang_runtime/src/thunk_util.rs
@@ -1,0 +1,27 @@
+use super::eval::{FlatThunk, Thunk, Thunk::*, VRef, Value::*};
+
+// example of a `rep_lang` list, fed by an iterator
+pub fn i64_iterator_to_flat_thunk_list<T: 'static>(itr: T) -> Thunk<VRef>
+where
+    T: Iterator<Item = i64> + Clone,
+{
+    UnevRust(Box::new(rec_list(itr)))
+}
+
+pub fn rec_list<T: 'static>(mut it: T) -> Box<dyn FnMut() -> FlatThunk>
+where
+    T: Iterator<Item = i64> + Clone,
+{
+    Box::new(move || {
+        match it.next() {
+            None => FlatThunk(Ev(VNil)),
+            Some(x) => {
+                let hd = Box::new(FlatThunk(Ev(VInt(x))));
+                // this seems suboptimal, due to excessive cloning, but I'm
+                // not sure how to do better --------------------\/
+                let tl = Box::new(FlatThunk(UnevRust(rec_list(it.clone()))));
+                FlatThunk(Ev(VCons(hd, tl)))
+            }
+        }
+    })
+}

--- a/rep_lang_runtime/src/thunk_util.rs
+++ b/rep_lang_runtime/src/thunk_util.rs
@@ -36,8 +36,8 @@ fn rec_vec(vec: Vec<i64>, idx: usize) -> Box<dyn FnMut() -> FlatThunk> {
             FlatThunk(Ev(VNil))
         } else {
             let hd = Box::new(FlatThunk(Ev(VInt(vec[idx]))));
-                // this seems suboptimal, due to excessive cloning, but I'm
-                // not sure how to do better ----------------\/
+            // this seems suboptimal, due to excessive cloning, but I'm
+            // not sure how to do better --------------------\/
             let tl = Box::new(FlatThunk(UnevRust(rec_vec(vec.clone(), idx + 1))));
             FlatThunk(Ev(VCons(hd, tl)))
         }


### PR DESCRIPTION
this PR builds on #33 & #35, as explained in #33.

## summary of changes

this PR switches the evaluation model from strict to lazy. we accomplish this by introducing a `Thunk` type which holds either (1) an evaluated `Value`, (2) an unevaluated `Expr` and `TermEnv` in which to evaluate the `Expr`, (3) an arbitrary Rust closure which returns a `Value`.

(3) is notable because it allows us to draw values from external sources into the language in a relatively principled way.

- [x] integrate `Thunk` type
- [x] implement evaluation of (2)
- [x] implement (3)
- [x] diagnose cause of duplicated entries in `sto_vec` and ideally remove them
    - this is not complete but was moved to #49